### PR TITLE
add read_user scope

### DIFF
--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/auth/GitLabApi.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/auth/GitLabApi.java
@@ -55,6 +55,10 @@ public class GitLabApi extends DefaultApi20 {
     @Override
     public String getAuthorizationUrl(OAuthConfig config) {
         Preconditions.checkValidUrl(config.getCallback(), "Must provide a valid url as callback. GitLab does not support OOB");
-        return String.format(url + "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code", config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
+        String url = String.format(this.url + "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code", config.getApiKey(), OAuthEncoder.encode(config.getCallback()));
+        if (config.hasScope()) {
+            url += "&scope=" + OAuthEncoder.encode(config.getScope());
+        }
+        return url;
     }
 }

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/auth/GitLabIdentityProvider.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/auth/GitLabIdentityProvider.java
@@ -109,6 +109,6 @@ public class GitLabIdentityProvider implements OAuth2IdentityProvider {
             throw new IllegalStateException("GitLab Authentication is disabled");
         }
         return new ServiceBuilder().provider(new GitLabApi(gitLabConfiguration.url())).apiKey(gitLabConfiguration.applicationId()).apiSecret(gitLabConfiguration.secret())
-                .grantType(OAuthConstants.AUTHORIZATION_CODE).callback(context.getCallbackUrl());
+                .grantType(OAuthConstants.AUTHORIZATION_CODE).scope("read_user").callback(context.getCallbackUrl());
     }
 }


### PR DESCRIPTION
Explicitly add `read_user` scope to be able to create a gitlab application token with only `read_user` scope (still working if you selected both `api` and `read_user`)

fixes #1 
