### PR TITLE
fix when gitlab server has no scope=read_user option

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabAuthPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabAuthPlugin.java
@@ -36,6 +36,8 @@ public class GitLabAuthPlugin implements Plugin {
     public static final String GITLAB_AUTH_APPLICATIONID = "sonar.auth.gitlab.applicationId";
     public static final String GITLAB_AUTH_SECRET = "sonar.auth.gitlab.secret";
     public static final String GITLAB_AUTH_ALLOWUSERSTOSIGNUP = "sonar.auth.gitlab.allowUsersToSignUp";
+    public static final String GITLAB_AUTH_SCOPE = "sonar.auth.gitlab.scope";
+
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "authentication";
@@ -50,7 +52,10 @@ public class GitLabAuthPlugin implements Plugin {
                 PropertyDefinition.builder(GITLAB_AUTH_SECRET).name("Secret").description("Secret provided by GitLab when registering the application.").category(CATEGORY).subCategory(SUBCATEGORY)
                         .type(PropertyType.PASSWORD).index(4).build(), PropertyDefinition.builder(GITLAB_AUTH_ALLOWUSERSTOSIGNUP).name("Allow users to sign-up")
                         .description("Allow new users to authenticate. When set to 'false', only existing users will be able to authenticate to the server.").category(CATEGORY)
-                        .subCategory(SUBCATEGORY).type(BOOLEAN).defaultValue(valueOf(true)).index(5).build());
+                        .subCategory(SUBCATEGORY).type(BOOLEAN).defaultValue(valueOf(true)).index(5).build(),
+                PropertyDefinition.builder(GITLAB_AUTH_SCOPE).name("Gitlab access scope").description("Scope provided by GitLab when access user info.").category(CATEGORY)
+                        .subCategory(SUBCATEGORY).defaultValue(valueOf("read_user")).index(6).build()
+                );
     }
 
     @Override

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabConfiguration.java
@@ -48,6 +48,10 @@ public class GitLabConfiguration {
         return settings.getString(GitLabAuthPlugin.GITLAB_AUTH_SECRET);
     }
 
+    public String scope() {
+        return settings.getString(GitLabAuthPlugin.GITLAB_AUTH_SCOPE);
+    }
+
     public boolean isEnabled() {
         return settings.getBoolean(GitLabAuthPlugin.GITLAB_AUTH_ENABLED) && applicationId() != null && secret() != null;
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabIdentityProvider.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabIdentityProvider.java
@@ -113,6 +113,6 @@ public class GitLabIdentityProvider implements OAuth2IdentityProvider {
             throw new IllegalStateException("GitLab Authentication is disabled");
         }
         return new ServiceBuilder().provider(new GitLabApi(gitLabConfiguration.url())).apiKey(gitLabConfiguration.applicationId()).apiSecret(gitLabConfiguration.secret())
-                .grantType(OAuthConstants.AUTHORIZATION_CODE).scope("read_user").callback(context.getCallbackUrl());
+                .grantType(OAuthConstants.AUTHORIZATION_CODE).scope(gitLabConfiguration.scope()).callback(context.getCallbackUrl());
     }
 }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/CallbackTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/CallbackTest.java
@@ -44,6 +44,8 @@ public class CallbackTest {
         Mockito.when(configuration.applicationId()).thenReturn("123");
         Mockito.when(configuration.secret()).thenReturn("456");
         Mockito.when(configuration.url()).thenReturn(String.format("http://%s:%d", gitlab.getHostName(), gitlab.getPort()));
+        Mockito.when(configuration.scope()).thenReturn("read_user");
+
         GitLabIdentityProvider gitLabIdentityProvider = new GitLabIdentityProvider(configuration);
 
         OAuth2IdentityProvider.CallbackContext callbackContext = Mockito.mock(OAuth2IdentityProvider.CallbackContext.class);
@@ -78,6 +80,7 @@ public class CallbackTest {
         Mockito.when(configuration.applicationId()).thenReturn("123");
         Mockito.when(configuration.secret()).thenReturn("456");
         Mockito.when(configuration.url()).thenReturn(String.format("http://%s:%d", gitlab.getHostName(), gitlab.getPort()));
+        Mockito.when(configuration.scope()).thenReturn("read_user");
         GitLabIdentityProvider gitLabIdentityProvider = new GitLabIdentityProvider(configuration);
 
         OAuth2IdentityProvider.CallbackContext callbackContext = Mockito.mock(OAuth2IdentityProvider.CallbackContext.class);

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabIdentityProviderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabIdentityProviderTest.java
@@ -51,6 +51,8 @@ public class GitLabIdentityProviderTest {
         Mockito.when(configuration.applicationId()).thenReturn("123");
         Mockito.when(configuration.secret()).thenReturn("456");
         Mockito.when(configuration.url()).thenReturn("http://server");
+        Mockito.when(configuration.scope()).thenReturn("read_user");
+
         GitLabIdentityProvider gitLabIdentityProvider = new GitLabIdentityProvider(configuration);
 
         OAuth2IdentityProvider.InitContext initContext = Mockito.mock(OAuth2IdentityProvider.InitContext.class);


### PR DESCRIPTION
On some version of gitlab, there is no scope=read_user parameter in the oauth authorize api. and the api call will receive a error message:
    The requested scope is invalid, unknown, or malformed.

the origin request url was: 
https://xxxx/oauth/authorize?client_id=xxxxx&redirect_uri=redirect_uri&response_type=code&scope=read_user

I add a config option to fix this problem.

the error screen snapshot see the attachment below:
<img width="833" alt="callback" src="https://cloud.githubusercontent.com/assets/1264866/25311100/0d6c60d6-282a-11e7-923c-23beb2744c7f.png">