### PR TITLE
Only allow users belonging to a GitLab group

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Copy Application Id and Secret in Settings of Sonarqube.
 | sonar.auth.gitlab.api_version | GitLab API version |
 | sonar.auth.gitlab.user_exceptions | List of usernames to keep intact (e.g. admin list), use , for multi |
 | sonar.auth.gitlab.ignore_certificate | Ignore Certificate for access GitLab, use for auto-signing cert (default false) | Administration, Variable | >= 2.0.0 |
+| sonar.auth.gitlab.group_allowed | Only allowed users who belong to this GitLab group ID, not applied if group ID is 0 (default 0) |
 
 # Sonarqube
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabAuthPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabAuthPlugin.java
@@ -43,6 +43,7 @@ public class GitLabAuthPlugin implements Plugin {
     public static final String GITLAB_AUTH_API_VERSION = "sonar.auth.gitlab.api_version";
     public static final String GITLAB_AUTH_USER_EXCEPTIONS = "sonar.auth.gitlab.user_exceptions";
     public static final String GITLAB_AUTH_IGNORE_CERT = "sonar.auth.gitlab.ignore_certificate";
+    public static final String GITLAB_AUTH_GROUP_ALLOWED = "sonar.auth.gitlab.group_allowed";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "authentication";
@@ -78,7 +79,12 @@ public class GitLabAuthPlugin implements Plugin {
                         category(CATEGORY).subCategory(SUBCATEGORY).
                         type(PropertyType.BOOLEAN).
                         defaultValue(String.valueOf(false)).
-                        index(11).build());
+                        index(11).build(),
+                PropertyDefinition.builder(GITLAB_AUTH_GROUP_ALLOWED).name("GitLab Group Allowed").description("The user has to belong to this GitLab group.").
+                        category(CATEGORY).subCategory(SUBCATEGORY).
+                        type(PropertyType.INTEGER).
+                        defaultValue(Integer.toString(0)).
+                        index(12).build());
     }
 
     @Override

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabConfiguration.java
@@ -85,4 +85,8 @@ public class GitLabConfiguration {
     public boolean ignoreCertificate() {
         return settings.getBoolean(GitLabAuthPlugin.GITLAB_AUTH_IGNORE_CERT);
     }
+
+    public Integer groupAllowed() {
+        return settings.getInt(GitLabAuthPlugin.GITLAB_AUTH_GROUP_ALLOWED);
+    }
 }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabGroup.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabGroup.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube :: GitLab Auth Plugin
- * Copyright (C) 2016-2017 TalanLabs
+ * Copyright (C) 2016-2018 TalanLabs
  * gabriel.allaigre@talanlabs.com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabGroup.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/auth/GitLabGroup.java
@@ -1,0 +1,39 @@
+/*
+ * SonarQube :: GitLab Auth Plugin
+ * Copyright (C) 2016-2017 TalanLabs
+ * gabriel.allaigre@talanlabs.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.talanlabs.sonar.plugins.gitlab.auth;
+
+public class GitLabGroup {
+
+    private final String name;
+    private final Integer id;
+
+    public GitLabGroup(String name, Integer id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+}

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/CallbackTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/auth/CallbackTest.java
@@ -50,6 +50,7 @@ public class CallbackTest {
         Mockito.when(configuration.secret()).thenReturn("456");
         Mockito.when(configuration.url()).thenReturn(String.format("http://%s:%d", gitlab.getHostName(), gitlab.getPort()));
         Mockito.when(configuration.scope()).thenReturn("read_user");
+        Mockito.when(configuration.groupAllowed()).thenReturn(0);
 
         GitLabIdentityProvider gitLabIdentityProvider = new GitLabIdentityProvider(configuration);
 
@@ -151,6 +152,7 @@ public class CallbackTest {
         Mockito.when(configuration.syncUserGroups()).thenReturn(true);
         Mockito.when(configuration.groups()).thenReturn(defaultGroup);
         Mockito.when(configuration.apiVersion()).thenReturn(apiVersion);
+        Mockito.when(configuration.groupAllowed()).thenReturn(0);
         if (useException) {
             Mockito.when(configuration.userExceptions()).thenReturn(Collections.singleton("username"));
         }


### PR DESCRIPTION
Hello!

I have a private Sonar but we use the main GitLab instance. This PR allows to configure a GitLab group which users have to belong in order to login to Sonar